### PR TITLE
fix(packaging): get only the version of the chart

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "center"
-version: "0.1.0"
+version: "0.1.1"
 usage: "Please see https://github.com/jfrog/chartcenter-plugin for usage"
 description: "Package dependencies Helm charts from ChartCenter"
 command: "$HELM_PLUGIN_DIR/scripts/center.sh"

--- a/scripts/center.sh
+++ b/scripts/center.sh
@@ -4,7 +4,7 @@ set -e
 
 CHART_NAME="${1//\/}"
 
-if [[ "${CHART_NAME}" == "" ]] 
+if [[ "${CHART_NAME}" == "" ]]
 then
     echo "Helm center plugin"
     echo
@@ -15,8 +15,8 @@ then
     exit 0
 fi
 
-CHART_VERSION=$(cat ${CHART_NAME}/Chart.yaml | grep -w "version:" | tr -d "[:blank:]" | cut -d ':' -f2)
-if [[ "${CHART_VERSION}" == "" ]] 
+CHART_VERSION=$(cat ${CHART_NAME}/Chart.yaml | grep -w "^version:" | tr -d "[:blank:]" | cut -d ':' -f2)
+if [[ "${CHART_VERSION}" == "" ]]
 then
     echo "Chart version is not found in Chart.yaml!"
     exit 1


### PR DESCRIPTION
Due to regex too open, all version in the Chart.yaml where retrieved, leading to a packaging error

fixes issue #3 