### PR TITLE
Update center.sh to find Chart.yaml within nested directories

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "center"
-version: "0.1.1"
+version: "0.1.2"
 usage: "Please see https://github.com/jfrog/chartcenter-plugin for usage"
 description: "Package dependencies Helm charts from ChartCenter"
 command: "$HELM_PLUGIN_DIR/scripts/center.sh"

--- a/scripts/center.sh
+++ b/scripts/center.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CHART_NAME="${1//\/}"
+CHART_NAME="${1%/}"
 
 if [[ "${CHART_NAME}" == "" ]]
 then


### PR DESCRIPTION
The current implementation does not support charts that are inside nested directories e.g.
```bash
$ helm center packaging/foo/bar
cat: packagingfoobar/Chart.yaml: No such file or directory
Chart version is not found in Chart.yaml!
Error: plugin "center" exited with error
```

The change enables to find `Chart.yaml` within nested directories.