### PR TITLE
Do not package charts

### DIFF
--- a/scripts/center.sh
+++ b/scripts/center.sh
@@ -15,13 +15,6 @@ then
     exit 0
 fi
 
-CHART_VERSION=$(cat ${CHART_NAME}/Chart.yaml | grep -w "^version:" | tr -d "[:blank:]" | cut -d ':' -f2)
-if [[ "${CHART_VERSION}" == "" ]]
-then
-    echo "Chart version is not found in Chart.yaml!"
-    exit 1
-fi
-
 echo "Running helm dependency update"
 helm dependency update ${CHART_NAME}
 echo

--- a/scripts/center.sh
+++ b/scripts/center.sh
@@ -33,7 +33,3 @@ do
   tar -xzf $f -C ${CHART_NAME}/charts
   rm -f $f
 done
-
-echo
-echo "Packaging ${CHART_NAME}-${CHART_VERSION}.tgz"
-tar -czf ${CHART_NAME}-${CHART_VERSION}.tgz ${CHART_NAME}


### PR DESCRIPTION
I think this is done prematurely because there are certain parameters that should be given on packaging such as `--version` and `--app-version`.